### PR TITLE
fix(torch): preserve state dtype on reset

### DIFF
--- a/rockpool/nn/modules/torch/torch_module.py
+++ b/rockpool/nn/modules/torch/torch_module.py
@@ -317,7 +317,7 @@ class TorchModule(Module, nn.Module):
         if init_func is not None:
             new_value = init_func(shape)
             new_value = (
-                new_value.to(value.device)
+                new_value.to(device=value.device, dtype=value.dtype)
                 if isinstance(value, torch.Tensor)
                 else new_value
             )

--- a/tests/tests_default/test_lif_torch.py
+++ b/tests/tests_default/test_lif_torch.py
@@ -332,6 +332,18 @@ def test_LIFTorch_reset():
     assert mod.bias.device == device
 
 
+def test_LIFTorch_reset_preserves_dtype():
+    from rockpool.nn.modules.torch.lif_torch import LIFTorch
+    import torch
+
+    mod = LIFTorch(10).to(torch.float64)
+    mod.reset_state()
+
+    assert mod.isyn.dtype == torch.float64
+    assert mod.vmem.dtype == torch.float64
+    assert mod.spikes.dtype == torch.float64
+
+
 def test_LIFTorch_tc_training():
     from rockpool.nn.modules.torch import LIFTorch
     from rockpool.parameters import Constant


### PR DESCRIPTION
## Summary

Fixes #31 by preserving the live tensor dtype when `TorchModule.reset_state()` regenerates a Torch-backed state value.

- Reset state tensors now retain both their device and dtype.
- Add CPU coverage for `LIFTorch.to(torch.float64)` followed by `reset_state()`.

## Validation

- `pytest -q tests/tests_default/test_lif_torch.py` — 15 passed, 1 skipped
- `pytest -q tests/tests_default/test_torch_module.py` — 7 passed
- `black==22.3.0 --check rockpool/nn/modules/torch/torch_module.py tests/tests_default/test_lif_torch.py`
- `git diff --check`

## Scope note

The current upstream `LIFTorch` float64 forward path also fails without a reset because its spike-generation implementation emits float32. This PR intentionally fixes only the reset-state dtype regression reported in #31; the broader forward-path issue is separate from this minimal change.
